### PR TITLE
uboot: do not erase ubi if fip volume is found

### DIFF
--- a/uboot-mtk-20220606/board/mediatek/common/ubi_helper.c
+++ b/uboot-mtk-20220606/board/mediatek/common/ubi_helper.c
@@ -477,7 +477,7 @@ static int write_ubi_fit_image(const void *data, size_t size,
 	if (ret)
 		return ret;
 
-	if (!find_ubi_volume("fit")) {
+	if (!find_ubi_volume("fit") && !find_ubi_volume("fip")) {
 		/* ubi is dirty, erase ubi and recreate volumes */
 		umount_ubi();
 		ubi_mtd_param_parse(mtd->name, NULL);

--- a/uboot-mtk-20230718-09eda825/board/mediatek/common/mtd_helper.c
+++ b/uboot-mtk-20230718-09eda825/board/mediatek/common/mtd_helper.c
@@ -28,6 +28,7 @@
 #include "untar.h"
 
 #define PART_UBI_NAME		"ubi"
+#define PART_FIP_NAME		"fip"
 #define PART_FIRMWARE_NAME	"firmware"
 #define PART_FIT_NAME		"fit"
 #define PART_KERNEL_NAME	"kernel"
@@ -654,7 +655,7 @@ static int write_ubi_fit_image(const void *data, size_t size,
 	if (ret)
 		return ret;
 
-	if (!ubi_find_volume(PART_FIT_NAME)) {
+	if (!ubi_find_volume(PART_FIT_NAME) && !ubi_find_volume(PART_FIP_NAME)) {
 		/* ubi is dirty, erase ubi and recreate volumes */
 		ubi_exit();
 		ret = mtd_erase_skip_bad(mtd, 0, mtd->size, mtd->size, NULL, NULL, false);


### PR DESCRIPTION
In this case FIP and all other data are stored in ubi.